### PR TITLE
update GraphQL to use react 16

### DIFF
--- a/lib/Mojolicious/Plugin/GraphQL.pm
+++ b/lib/Mojolicious/Plugin/GraphQL.pm
@@ -484,8 +484,8 @@ add "&raw" to the end of the URL within a browser.
   </style>
   <link href="//cdn.jsdelivr.net/npm/graphiql@<%= $graphiql_version %>/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>                                                                                               
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script> 
   <script src="//cdn.jsdelivr.net/npm/graphiql@<%= $graphiql_version %>/graphiql.min.js"></script>
   <% if ($subscriptionEndpoint) { %>
   <!-- ADDED -->


### PR DESCRIPTION
fixes bug in current graphiql.min.js
`Error: GraphiQL 0.18.0 and after is not compatible with React 15 or below.
If you are using a CDN source (jsdelivr, unpkg, etc), follow this example:
https://github.com/graphql/graphiql/blob/master/examples/graphiql-cdn/index.html#L49
`